### PR TITLE
Add Nihoner SRS Flashcards plugin skeleton

### DIFF
--- a/nihoner-flashcards-srs/README.md
+++ b/nihoner-flashcards-srs/README.md
@@ -1,0 +1,3 @@
+# Nihoner SRS Flashcards
+
+A WordPress plugin for spaced repetition study of Japanese words and kanji using the SM-2 algorithm.

--- a/nihoner-flashcards-srs/assets/css/srs-styles.css
+++ b/nihoner-flashcards-srs/assets/css/srs-styles.css
@@ -1,0 +1,5 @@
+.srs-card {
+    text-align: center;
+    font-size: 2rem;
+    padding: 2rem;
+}

--- a/nihoner-flashcards-srs/assets/js/srs-review.js
+++ b/nihoner-flashcards-srs/assets/js/srs-review.js
@@ -1,0 +1,3 @@
+(function(){
+    console.log('SRS review loaded');
+})();

--- a/nihoner-flashcards-srs/includes/class-srs-cpt.php
+++ b/nihoner-flashcards-srs/includes/class-srs-cpt.php
@@ -1,0 +1,28 @@
+<?php
+class Nihoner_SRS_CPT {
+    public function __construct() {
+        add_action( 'init', array( $this, 'register_cpts' ) );
+    }
+
+    public function register_cpts() {
+        register_post_type( 'srs_flashcard', array(
+            'labels' => array(
+                'name'          => __( 'Flashcards', 'nihoner-srs' ),
+                'singular_name' => __( 'Flashcard', 'nihoner-srs' ),
+            ),
+            'public'      => false,
+            'show_ui'     => true,
+            'supports'    => array( 'title', 'editor' ),
+        ) );
+
+        register_post_type( 'srs_deck', array(
+            'labels' => array(
+                'name'          => __( 'Decks', 'nihoner-srs' ),
+                'singular_name' => __( 'Deck', 'nihoner-srs' ),
+            ),
+            'public'      => false,
+            'show_ui'     => true,
+            'supports'    => array( 'title' ),
+        ) );
+    }
+}

--- a/nihoner-flashcards-srs/includes/class-srs-cron.php
+++ b/nihoner-flashcards-srs/includes/class-srs-cron.php
@@ -1,0 +1,22 @@
+<?php
+class Nihoner_SRS_Cron {
+    const HOOK = 'srs_daily_notify';
+
+    public function __construct() {
+        add_action( self::HOOK, array( $this, 'daily_notify' ) );
+    }
+
+    public static function activate() {
+        if ( ! wp_next_scheduled( self::HOOK ) ) {
+            wp_schedule_event( strtotime( '08:00:00' ), 'daily', self::HOOK );
+        }
+    }
+
+    public static function deactivate() {
+        wp_clear_scheduled_hook( self::HOOK );
+    }
+
+    public function daily_notify() {
+        // Placeholder for email notifications.
+    }
+}

--- a/nihoner-flashcards-srs/includes/class-srs-deck.php
+++ b/nihoner-flashcards-srs/includes/class-srs-deck.php
@@ -1,0 +1,18 @@
+<?php
+class Nihoner_SRS_Deck {
+    public function __construct() {
+        add_action( 'init', array( $this, 'register_taxonomies' ) );
+    }
+
+    public function register_taxonomies() {
+        register_taxonomy( 'srs_deck_category', 'srs_deck', array(
+            'labels' => array(
+                'name'          => __( 'Deck Categories', 'nihoner-srs' ),
+                'singular_name' => __( 'Deck Category', 'nihoner-srs' ),
+            ),
+            'public'      => false,
+            'show_ui'     => true,
+            'hierarchical'=> true,
+        ) );
+    }
+}

--- a/nihoner-flashcards-srs/includes/class-srs-meta-boxes.php
+++ b/nihoner-flashcards-srs/includes/class-srs-meta-boxes.php
@@ -1,0 +1,20 @@
+<?php
+class Nihoner_SRS_Meta_Boxes {
+    public function __construct() {
+        add_action( 'add_meta_boxes', array( $this, 'add_boxes' ) );
+        add_action( 'save_post', array( $this, 'save_meta' ) );
+    }
+
+    public function add_boxes() {
+        add_meta_box( 'srs_flashcard_meta', __( 'Flashcard SRS Data', 'nihoner-srs' ), array( $this, 'render_box' ), 'srs_flashcard', 'normal', 'default' );
+    }
+
+    public function render_box( $post ) {
+        $next_review = get_post_meta( $post->ID, '_srs_next_review', true );
+        echo '<p>' . esc_html__( 'Next review:', 'nihoner-srs' ) . ' ' . esc_html( $next_review ) . '</p>';
+    }
+
+    public function save_meta( $post_id ) {
+        // Placeholder for saving meta fields.
+    }
+}

--- a/nihoner-flashcards-srs/includes/class-srs-rest.php
+++ b/nihoner-flashcards-srs/includes/class-srs-rest.php
@@ -1,0 +1,53 @@
+<?php
+class Nihoner_SRS_REST {
+    public function __construct() {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    public function register_routes() {
+        register_rest_route( 'srs/v1', '/decks', array(
+            'methods'  => 'GET',
+            'callback' => array( $this, 'get_decks' ),
+            'permission_callback' => array( $this, 'permissions' ),
+        ) );
+
+        register_rest_route( 'srs/v1', '/review', array(
+            'methods'  => 'GET',
+            'callback' => array( $this, 'get_review_card' ),
+            'permission_callback' => array( $this, 'permissions' ),
+        ) );
+
+        register_rest_route( 'srs/v1', '/answer', array(
+            'methods'  => 'POST',
+            'callback' => array( $this, 'post_answer' ),
+            'permission_callback' => array( $this, 'permissions' ),
+        ) );
+    }
+
+    public function permissions() {
+        return current_user_can( 'read' );
+    }
+
+    public function get_decks( $request ) {
+        $decks = get_posts( array( 'post_type' => 'srs_deck', 'numberposts' => -1 ) );
+        $data  = array();
+        foreach ( $decks as $deck ) {
+            $data[] = array(
+                'id'    => $deck->ID,
+                'title' => $deck->post_title,
+            );
+        }
+        return rest_ensure_response( $data );
+    }
+
+    public function get_review_card( $request ) {
+        // Placeholder for fetching due card.
+        return rest_ensure_response( array() );
+    }
+
+    public function post_answer( $request ) {
+        // Placeholder for processing user answer.
+        return rest_ensure_response( array() );
+    }
+}
+

--- a/nihoner-flashcards-srs/includes/class-srs-scheduler.php
+++ b/nihoner-flashcards-srs/includes/class-srs-scheduler.php
@@ -1,0 +1,39 @@
+<?php
+class Nihoner_SRS_Scheduler {
+    public function __construct() {}
+
+    public function schedule( $card_id, $quality ) {
+        $easiness   = (float) get_post_meta( $card_id, '_srs_easiness', true );
+        $interval    = (int) get_post_meta( $card_id, '_srs_interval', true );
+        $repetitions = (int) get_post_meta( $card_id, '_srs_repetitions', true );
+
+        if ( ! $easiness ) {
+            $easiness = 2.5;
+            $interval = 1;
+            $repetitions = 0;
+        }
+
+        if ( $quality < 3 ) {
+            $repetitions = 0;
+            $interval    = 1;
+        } else {
+            $repetitions++;
+            if ( $repetitions === 1 ) {
+                $interval = 1;
+            } elseif ( $repetitions === 2 ) {
+                $interval = 6;
+            } else {
+                $interval = round( $interval * $easiness );
+            }
+        }
+
+        $easiness = max( 1.3, $easiness + 0.1 - (5 - $quality) * (0.08 + (5 - $quality) * 0.02) );
+        $next     = strtotime( '+' . $interval . ' days' );
+
+        update_post_meta( $card_id, '_srs_easiness', $easiness );
+        update_post_meta( $card_id, '_srs_interval', $interval );
+        update_post_meta( $card_id, '_srs_repetitions', $repetitions );
+        update_post_meta( $card_id, '_srs_next_review', date( 'Y-m-d H:i:s', $next ) );
+        update_post_meta( $card_id, '_srs_last_quality', $quality );
+    }
+}

--- a/nihoner-flashcards-srs/includes/class-srs-settings.php
+++ b/nihoner-flashcards-srs/includes/class-srs-settings.php
@@ -1,0 +1,14 @@
+<?php
+class Nihoner_SRS_Settings {
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'add_menu' ) );
+    }
+
+    public function add_menu() {
+        add_options_page( 'SRS Settings', 'SRS Settings', 'manage_options', 'srs-settings', array( $this, 'render' ) );
+    }
+
+    public function render() {
+        echo '<h1>' . esc_html__( 'SRS Settings', 'nihoner-srs' ) . '</h1>';
+    }
+}

--- a/nihoner-flashcards-srs/nihoner-flashcards-srs.php
+++ b/nihoner-flashcards-srs/nihoner-flashcards-srs.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Plugin Name: Nihoner SRS Flashcards
+ * Description: Spaced repetition flashcards for learning Japanese using the SM-2 algorithm.
+ * Version: 0.1.0
+ * Author: Codex
+ * Text Domain: nihoner-srs
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Define plugin constants.
+ */
+define( 'NIHONER_SRS_PATH', plugin_dir_path( __FILE__ ) );
+define( 'NIHONER_SRS_URL', plugin_dir_url( __FILE__ ) );
+
+define( 'NIHONER_SRS_VERSION', '0.1.0' );
+
+// Include required classes.
+require_once NIHONER_SRS_PATH . 'includes/class-srs-cpt.php';
+require_once NIHONER_SRS_PATH . 'includes/class-srs-deck.php';
+require_once NIHONER_SRS_PATH . 'includes/class-srs-meta-boxes.php';
+require_once NIHONER_SRS_PATH . 'includes/class-srs-rest.php';
+require_once NIHONER_SRS_PATH . 'includes/class-srs-cron.php';
+require_once NIHONER_SRS_PATH . 'includes/class-srs-settings.php';
+require_once NIHONER_SRS_PATH . 'includes/class-srs-scheduler.php';
+
+/**
+ * Initialize plugin components.
+ */
+add_action( 'plugins_loaded', function() {
+    new Nihoner_SRS_CPT();
+    new Nihoner_SRS_Deck();
+    new Nihoner_SRS_Meta_Boxes();
+    new Nihoner_SRS_REST();
+    new Nihoner_SRS_Cron();
+    new Nihoner_SRS_Settings();
+    new Nihoner_SRS_Scheduler();
+} );
+
+// Activation and deactivation hooks.
+register_activation_hook( __FILE__, array( 'Nihoner_SRS_Cron', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'Nihoner_SRS_Cron', 'deactivate' ) );

--- a/nihoner-flashcards-srs/uninstall.php
+++ b/nihoner-flashcards-srs/uninstall.php
@@ -1,0 +1,5 @@
+<?php
+// Cleanup database if needed.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit();
+}


### PR DESCRIPTION
## Summary
- add base plugin structure for Nihoner SRS Flashcards
- register custom post types, taxonomies and REST endpoints
- implement simple SM-2 scheduling algorithm
- provide cron setup and settings page placeholders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eedd605108332b399200284fb7f91